### PR TITLE
Remove admin middleware from all-messages route

### DIFF
--- a/backend/routes/messageRoutes.js
+++ b/backend/routes/messageRoutes.js
@@ -55,7 +55,7 @@ router.get("/messages/:chatId", async (req, res) => {
 });
 
 // New route to get all messages (admin only)
-router.get("/all-messages", admin, async (req, res) => {
+router.get("/all-messages", async (req, res) => {
   try {
     const messages = await Message.find().populate({
       path: "sender",


### PR DESCRIPTION
Eliminate the admin requirement for accessing the all-messages route, allowing all users to retrieve messages.